### PR TITLE
Fix "Use clipboard as background" incorrect image size

### DIFF
--- a/Gui/BrushFactoryWindow.cs
+++ b/Gui/BrushFactoryWindow.cs
@@ -2543,7 +2543,7 @@ namespace BrushFactory
                         graphics.FillRectangle(backgroundBrush, 0, 0, background.Width, background.Height);
                     }
 
-                    graphics.DrawImage(clipboardImage, 0, 0);
+                    graphics.DrawImage(clipboardImage, 0, 0, background.Width, background.Height);
                 }
             }
 


### PR DESCRIPTION
Fix "Use clipboard as background" having input image being scaled by DPI-aware value which causes incorrect sizing compared to canvas size.

`Graphics#DrawImage(Image image, int x, int y)` will use the DPI value of the target device to scale the drawn image unless the image size is specified directly (see `Graphics#DrawImage(Image image, int x, int y, int width, int height)` overload). This is problematic because Paint.NET canvas and Brush Factory's canvas are not scaled by the device DPI. This change fixes this issue by using the stated overload, using the background canvas' width and height.